### PR TITLE
Added isStatic option

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,16 +89,16 @@ In your base file, put `{{content}}` in the location where you want your data wi
 #### `isStatic` (optional) 
 default: `true`
 
-#### `nonStatic` (optional) - Deprecated
-default: `false`
-Use `isStatic`; `nonStatic` is only included for backwards compatibility.
-
 Since this is a static site generator, by default, it will render the React Templates using `renderToStaticMarkup()`
 
 However, you may choose to make a static site generator with React functionalities (similar to first render from server) and subsequently pull page routes via JavaScript / React.
 
-Setting this parameter to true will cause templates to be parsed using `renderToString()`
+Setting this parameter to `false` will cause templates to be parsed using `renderToString()`
 
+#### `nonStatic` (optional) - Deprecated
+default: `false`
+
+Use `isStatic`; `nonStatic` is only included for backwards compatibility.
 
 #### `directory` (optional) 
 default: `templates`

--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ npm install metalsmith-react-templates
   "plugins": {
     "metalsmith-react-templates": {
       "baseFile": "base.html",
-      "nonStatic": false,
+      "isStatic": true,
       "directory": "templates"
     }
   }
@@ -57,7 +57,7 @@ metalsmith.use(templates());
 ```js
 metalsmith.use(templates({
   baseFile: 'base.html'
-  nonStatic: false,
+  isStatic: true,
   directory: 'templates'
 }));
 ```
@@ -86,8 +86,12 @@ This is similar to the index.html file which you React.render() your components 
 
 In your base file, put `{{content}}` in the location where you want your data will render into.
 
-#### `nonStatic` (optional) 
+#### `isStatic` (optional) 
+default: `true`
+
+#### `nonStatic` (optional) - Deprecated
 default: `false`
+Use `isStatic`; `nonStatic` is only included for backwards compatibility.
 
 Since this is a static site generator, by default, it will render the React Templates using `renderToStaticMarkup()`
 

--- a/examples/index.js
+++ b/examples/index.js
@@ -11,7 +11,7 @@ new Metalsmith(__dirname)
     babel: true,
     directory: 'templates',
     baseFile: 'base.html',
-    nonStatic: true
+    isStatic: false
   }))
   .use(browserify({
     files: ['../scripts/loader.js'],

--- a/src/renderReactTemplates.js
+++ b/src/renderReactTemplates.js
@@ -5,11 +5,16 @@ import React from 'react';
  */
 export default (templatePath, props = {}, options = {}, callback = () => {}) => {
 
-  // Option for nonStatic rendering
-  // Usually used if we want to do a static first load
+  // Option for isStatic rendering
+  // False if we want to do a static first load
   // but dynamic interation subsequently.
   // i.e. React Server side rendering style
-  const isNonStatic = options.nonStatic;
+  var staticConst = (void 0 !== options.isStatic) ? options.isStatic : true;
+  if (void 0 !== options.nonStatic) {
+    staticConst = !options.nonStatic;
+    console.warn('option: isStatic should be used instead of nonStatic.');
+  }
+  const isStatic = staticConst;
 
   // Initialize the template as a factory
   // and apply the options into the factory.
@@ -19,13 +24,12 @@ export default (templatePath, props = {}, options = {}, callback = () => {}) => 
   try {
     let content;
 
-    if (isNonStatic){
-      // renderToString (with React ids)
-      content = React.renderToString(component);
-
-    } else {
+    if (isStatic){
       // renderToStaticMarkup (React ids removed)
       content = React.renderToStaticMarkup(component);
+    } else {
+      // renderToString (with React ids)
+      content = React.renderToString(component);
     }
 
     callback(null, content);


### PR DESCRIPTION
I've included nonStatic for backwards compatibility.

I've not bumped the version number, do you want me to do that?

The backward compatibility is a bit messy but:
```Javascript
var staticConst = (void 0 !== options.isStatic) ? options.isStatic : true;
  if (void 0 !== options.nonStatic) {
    staticConst = !options.nonStatic;
    console.warn('option: isStatic should be used instead of nonStatic.');
  }
  const isStatic = staticConst;
```
can be changed to:
```Javascript
const isStatic = (void 0 !== options.isStatic) ? options.isStatic : true;
```
when you don't want to support `nonStatic` any more.