### PR TITLE
Add .babelrc for examples and add dependencies to package.json

### DIFF
--- a/examples/.babelrc
+++ b/examples/.babelrc
@@ -1,0 +1,4 @@
+{
+    "presets": ["es2015", "react"],
+    "plugins": ["add-module-exports"]
+}

--- a/examples/package.json
+++ b/examples/package.json
@@ -8,9 +8,14 @@
   },
   "author": "",
   "dependencies": {
+    "babel-plugin-add-module-exports": "^0.1.2",
+    "babel-preset-es2015": "^6.5.0",
+    "babel-preset-react": "^6.5.0",
     "babelify": "^7.2.0",
     "browserify": "^13.0.0",
     "metalsmith": "^2.1.0",
-    "metalsmith-react-templates": ".."
+    "metalsmith-react-templates": "^4.0.0",
+    "react": "^0.14.7",
+    "react-dom": "^0.14.7"
   }
 }


### PR DESCRIPTION
First approaching the example, I would expect the following sequence to work, but it doesn't:

```bash
git clone https://github.com/yeojz/metalsmith-react-templates.git
cd metalsmith-react-templates/examples/
# replace line in package.json to install from registry: "metalsmith-react-templates": "^4.0.0"
npm install
npm install react react-dom babel-preset-react babel-preset-es2015
node build
```

There is some trouble with babel and after some non-obvious effort you can repair things, but difficulties arises from the fact that the example isn't independent from the module's build code. I think others run into trouble with the example as well (e.g. https://github.com/yeojz/metalsmith-react-templates/issues/19), so I think making it independent is worthwhile.

This PR gives the example its own `.babelrc` and makes all the build dependencies explicit in `package.json`. With these changes, the example builds even if you copied the directory out of this repo.