### PR TITLE
Add an option to preserve props for use in downstream metalsmith tasks

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,6 +100,7 @@ All parameters are optional.
 | `noConflict` | `true` | By default, this plugin will read from the `rtemplate` key in your `yaml` front matter. However, if this is the only templating plugin, you may set `noConflict` to `false` to use the `template` key instead.
 | `pattern` | `**/*` | Specifies a file filter pattern.
 | `preserve` | `false` | Stores a copy of un-templated contents into `rawContents` meta which you can access in your React components.
+| `preserveProps` | `false` | Stores a copy of the props objects provided to the Reach template into `props` which you can access in downstream plugins.
 | `requireIgnoreExt` | `[ ]` | A list of extensions to ignore. <br /><br /> For example, `{requireIgnoreExt: ['.css']}` would ignore declarations like `require('file.css')`
 | `templateTag` | `null` | Accepts a function `pattern(key)` which returns a regex object used to find and replace template tags in your output file. <br /><br /> By default, template tags are assumed to be `{{tag}}`. You may use this to allow for other tag formats (eg. you may want `<!--tag-->` instead). <br /> <br /> Check the test case for an example.
 | `tooling` | `{ }` | Options to pass into the `babel` transpiler.

--- a/src/index.js
+++ b/src/index.js
@@ -27,6 +27,7 @@ export default (options = {}) => {
         noConflict = true,
         pattern = '**/*',
         preserve = false,
+        preserveProps = false,
         requireIgnoreExt = [],
         templateTag = null,
         tooling = {}
@@ -77,6 +78,13 @@ export default (options = {}) => {
             if (preserve){
                 debug('Preserving untouched contents: %s', file);
                 data.rawContents = data.contents;
+            }
+
+            // if opt.preserveProps is set
+            // preserve the props provided to the template
+            if (preserveProps) {
+                debug('Preserving props: %s', file);
+                data.props = props;
             }
 
             // Start Conversion Process


### PR DESCRIPTION
Adds an option to pass along the props object provided to the template with the `preserveProps` option. This makes it much easier to use the props downstream without essentially reconstructing it.

My current use case is to store the props object in the script bundle via webpack and use it to mount the template component in the client.