### PR TITLE
Add `propsKey` option for custom props

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,6 +100,7 @@ All parameters are optional.
 | `noConflict` | `true` | By default, this plugin will read from the `rtemplate` key in your `yaml` front matter. However, if this is the only templating plugin, you may set `noConflict` to `false` to use the `template` key instead.
 | `pattern` | `**/*` | Specifies a file filter pattern.
 | `preserve` | `false` | Stores a copy of un-templated contents into `rawContents` meta which you can access in your React components.
+| `propsKey` | `null` | Specifies a key containing the props to provide to the template. If left unspecified, a generic props containing all keys is provided.
 | `requireIgnoreExt` | `[ ]` | A list of extensions to ignore. <br /><br /> For example, `{requireIgnoreExt: ['.css']}` would ignore declarations like `require('file.css')`
 | `templateTag` | `null` | Accepts a function `pattern(key)` which returns a regex object used to find and replace template tags in your output file. <br /><br /> By default, template tags are assumed to be `{{tag}}`. You may use this to allow for other tag formats (eg. you may want `<!--tag-->` instead). <br /> <br /> Check the test case for an example.
 | `tooling` | `{ }` | Options to pass into the `babel` transpiler.

--- a/src/index.js
+++ b/src/index.js
@@ -29,7 +29,8 @@ export default (options = {}) => {
         preserve = false,
         requireIgnoreExt = [],
         templateTag = null,
-        tooling = {}
+        tooling = {},
+        propsKey = null
     } = options;
 
     let {
@@ -65,11 +66,16 @@ export default (options = {}) => {
 
             // Prepare Props
             debug('Preparing Props: %s', file);
-            let props = {
-                ...data,
-                filename: file,
-                metadata,
-                contents: data.contents.toString()
+            let props = null;
+            if (propsKey) {
+                props = data[propsKey];
+            } else {
+                props = {
+                    ...data,
+                    filename: file,
+                    metadata,
+                    contents: data.contents.toString()
+                };
             }
 
             // if opt.preserve is set


### PR DESCRIPTION
As discussed in #28, this PR adds a `propsKey` option that specifies a key containing the props to provide to the template.