### PR TITLE
Keep directory structure.

### DIFF
--- a/src/fn.js
+++ b/src/fn.js
@@ -100,7 +100,7 @@ const getFilename = (directory, basename, extension) => {
     if (directory === '.') {
         return `${basename}${extension}`;
     }
-    return `${directory}${basename}${extension}`;
+    return path.join(directory, `${basename}${extension}`);
 }
 
 const renameFileExtension = (filename, extension) => {

--- a/tests/fixtures/src/subdir/structure.md
+++ b/tests/fixtures/src/subdir/structure.md
@@ -1,0 +1,5 @@
+---
+title: Test subdirectory structure
+---
+
+Test content

--- a/tests/specs/index.spec.js
+++ b/tests/specs/index.spec.js
@@ -61,6 +61,19 @@ describe('index', () => {
         });
     });
 
+    it('should keep subdirectory structure', (done) => {
+        const plugin = index({extension: '.html'});
+
+        const test = {
+            'subdir/structure.md': {...files['subdir/structure.md']}
+        }
+
+        plugin(test, metalsmith, () => {
+            expect(test['subdir/structure.html']).to.exist;
+            done();
+        });
+    });
+
     it('should use a base file', (done) => {
         const plugin = index({baseFile: 'base.html'});
 


### PR DESCRIPTION
Before this change, if you had files in nested directories like `subdir/whatever.md` they would be written at the toplevel as `subdirwhatever.md`.