### PR TITLE
Return whole error object in done callback

### DIFF
--- a/src/jsx-render-engine/core/processor.js
+++ b/src/jsx-render-engine/core/processor.js
@@ -20,7 +20,7 @@ const noTemplate = (files, data, name, debug) => {
 
 const callbackOrThrow = (err, done) => {
   if (isFunction(done)) {
-    done(err.message);
+    done(err);
     return;
   }
   throw new Error(err);


### PR DESCRIPTION
The stack trace on render errors gets lost when you only return the `error.message.`. This makes it hard to debug errors that occur during rendering.

What do you think?